### PR TITLE
Reset sequence position when playing completed.

### DIFF
--- a/DPA_Musicsheets/ViewModels/MidiPlayerViewModel.cs
+++ b/DPA_Musicsheets/ViewModels/MidiPlayerViewModel.cs
@@ -44,6 +44,7 @@ namespace DPA_Musicsheets.ViewModels
             _sequencer.PlayingCompleted += (playingSender, playingEvent) =>
             {
                 _sequencer.Stop();
+                _sequencer.Position = 0;
                 _running = false;
             };
 


### PR DESCRIPTION
The sequencer doesn't reset its position after the song is completed playing. Which causes the midi player buttons to not work properly.